### PR TITLE
Cohorts via Business Unit or on its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ Uses:
 
 ### Business Units
 
+Business Units are programs: Denver WDI (1), Boulder WDI (2), etc.
+
 * `/api/v1/business-units`
+* `/api/v1/business-units/:business_unit_id`
 * `/api/v1/business-units/:business_unit_id/cohorts`
-* `/api/v1/business-units/:business_unit_id/cohorts/:cohort_id`
+* `/api/v1/business-units/:business_unit_id/cohorts/:id`
 
 ### Cohorts
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Business Units are programs: Denver WDI (1), Boulder WDI (2), etc.
 * `/api/v1/business-units`
 * `/api/v1/business-units/:business_unit_id`
 * `/api/v1/business-units/:business_unit_id/cohorts`
-* `/api/v1/business-units/:business_unit_id/cohorts/:id`
+* `/api/v1/business-units/:business_unit_id/cohorts/:cohort_id`
 
 ### Cohorts
 

--- a/app/models/Cohort.js
+++ b/app/models/Cohort.js
@@ -6,7 +6,7 @@ var deserializeLearnCohort = require("./deserializers/learn-cohort");
 
 class Cohort extends Model {
     static getOne(id){
-        return LocalCohort.getOne(id)
+        return LocalCohort.getOneByLearnId(id)
         .then(localCohort => {
             return LearnCohort.getOne(localCohort.learn_id)
             .then(deserializeLearnCohort)

--- a/app/models/LocalCohort.js
+++ b/app/models/LocalCohort.js
@@ -13,6 +13,12 @@ class LocalCohort extends Model {
             .where("id", id)
             .first();
     }
+    static getOneByLearnId(id){
+        return this.query()
+            .select(this.columns)
+            .where("learn_id", id)
+            .first();
+    }
     static getSome(ids){
         return this.query()
             .select(this.columns)

--- a/app/routes/business-units.js
+++ b/app/routes/business-units.js
@@ -5,5 +5,7 @@ var cohortController = require("../controllers/cohorts");
 
 router.get("/", businessUnitController.multiple);
 router.get("/:business_unit_id", businessUnitController.single);
+router.get("/:business_unit_id/cohorts", cohortController.byBusinessUnit);
+router.get("/:business_unit_id/cohorts/:cohort_id", cohortController.single);
 
 module.exports = router;


### PR DESCRIPTION
Previously we were trying to lookup by `localCohort.id` when we're showing `localCohort.learn_id`